### PR TITLE
Add more flexible end cap styles

### DIFF
--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleEndcapFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleEndcapFragment.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2015 Brent Marriott
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hookedonplay.decoviewsample;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.AlphaAnimation;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.hookedonplay.decoviewlib.DecoView;
+import com.hookedonplay.decoviewlib.charts.EdgeDetail;
+import com.hookedonplay.decoviewlib.charts.EndCapType;
+import com.hookedonplay.decoviewlib.charts.SeriesItem;
+import com.hookedonplay.decoviewlib.events.DecoEvent;
+
+public class SampleEndcapFragment extends SampleFragment {
+    private int mSeries1Index;
+    private String mProgress;
+
+    public SampleEndcapFragment() {
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_sample_endcap, container, false);
+    }
+
+    @Override
+    protected void createTracks() {
+        setDemoFinished(false);
+        final View view = getView();
+        final DecoView decoView = getDecoView();
+        if (view == null || decoView == null) {
+            return;
+        }
+
+        view.setBackgroundColor(Color.argb(255, 196, 196, 128));
+
+        decoView.executeReset();
+        decoView.deleteAll();
+
+        final float mSeriesMax = 100f;
+
+        SeriesItem seriesBack1Item = new SeriesItem.Builder(COLOR_BACK)
+                .setRange(0, mSeriesMax, mSeriesMax)
+                .setLineWidth(getDimension(40))
+                .build();
+
+        decoView.addSeries(seriesBack1Item);
+
+        SeriesItem series1Item = new SeriesItem.Builder(COLOR_NEUTRAL)
+                .setRange(0, mSeriesMax, 0)
+                .setInitialVisibility(false)
+                .setLineWidth(getDimension(30))
+                .setEndCap(EndCapType.CAP_CONCAVE)
+                .setShowPointWhenEmpty(true)
+                .build();
+
+        mSeries1Index = decoView.addSeries(series1Item);
+
+        TextView textListener = (TextView) view.findViewById(R.id.textProgress);
+        addFitListener(series1Item, textListener);
+    }
+
+    @Override
+    protected void setupEvents() {
+        final DecoView arcView = getDecoView();
+        final View view = getView();
+        if (view == null || arcView == null || arcView.isEmpty()) {
+            return;
+        }
+
+        addAnimation(arcView, mSeries1Index, 100.0f, 2000, "Cycle %.0f Km", COLOR_GREEN, false);
+        addAnimation(arcView, mSeries1Index, 16.4f, 9000, "Run %.1f Km", COLOR_YELLOW, false);
+        addAnimation(arcView, mSeries1Index, 58f, 16000, "Gym %.0f min", COLOR_PINK, false);
+        addAnimation(arcView, mSeries1Index, 3.38f, 23000, "Swim %.2f Km", COLOR_BLUE, true);
+    }
+
+    private void addAnimation(final DecoView arcView,
+                              int series, float moveTo, int delay,
+                              final String format, final int color, final boolean restart) {
+
+        DecoEvent.ExecuteEventListener listener = new DecoEvent.ExecuteEventListener() {
+            @Override
+            public void onEventStart(DecoEvent event) {
+                mProgress = format;
+            }
+
+            @Override
+            public void onEventEnd(DecoEvent event) {
+                if (restart) {
+                    setupEvents();
+                }
+            }
+        };
+
+        arcView.addEvent(new DecoEvent.Builder(moveTo)
+                .setIndex(series)
+                .setDelay(delay)
+                .setDuration(5000)
+                .setListener(listener)
+                .setColor(color)
+                .build());
+    }
+
+    private void addFitListener(@NonNull final SeriesItem seriesItem, @NonNull final TextView view) {
+        seriesItem.addArcSeriesItemListener(new SeriesItem.SeriesItemListener() {
+
+            @Override
+            public void onSeriesItemAnimationProgress(float percentComplete, float currentPosition) {
+                if (mProgress != null) {
+                    if (mProgress.contains("%%")) {
+                        view.setText(String.format(mProgress, (1.0f - (currentPosition / seriesItem.getMaxValue())) * 100f));
+                    } else {
+                        view.setText(String.format(mProgress, currentPosition));
+                    }
+                }
+            }
+
+            @Override
+            public void onSeriesItemDisplayProgress(float percentComplete) {
+
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleEndcapFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleEndcapFragment.java
@@ -74,6 +74,7 @@ public class SampleEndcapFragment extends SampleFragment {
                 .setLineWidth(getDimension(30))
                 .setEndCap(EndCapType.CAP_CONCAVE)
                 .setShowPointWhenEmpty(true)
+                .addEdgeDetail(new EdgeDetail(EdgeDetail.EdgeType.EDGE_INNER, COLOR_EDGE, 0.3f))
                 .build();
 
         mSeries1Index = decoView.addSeries(series1Item);

--- a/app/src/main/java/com/hookedonplay/decoviewsample/SamplerAdapter.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SamplerAdapter.java
@@ -21,7 +21,7 @@ import android.support.v4.app.FragmentStatePagerAdapter;
 import android.view.ViewGroup;
 
 public class SamplerAdapter extends FragmentStatePagerAdapter {
-    private int mCount = 10;
+    private int mCount = 11;
 
     public SamplerAdapter(FragmentManager fm) {
         super(fm);
@@ -55,6 +55,8 @@ public class SamplerAdapter extends FragmentStatePagerAdapter {
                 return new Sample4Fragment();
             case 9:
                 return new SamplePauseFragment();
+            case 10:
+                return new SampleEndcapFragment();
             default:
                 return new SampleFitFragment();
 

--- a/app/src/main/res/layout/fragment_sample_endcap.xml
+++ b/app/src/main/res/layout/fragment_sample_endcap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/layout_replay"/>
+
+    <com.hookedonplay.decoviewlib.DecoView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/dynamicArcView"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp">
+
+    </com.hookedonplay.decoviewlib.DecoView>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:text="Fit Tracker"
+        android:id="@+id/textProgress"
+        android:layout_above="@+id/textView2"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="16dp"/>
+
+</RelativeLayout>

--- a/decoviewlib/build.gradle
+++ b/decoviewlib/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 22
         versionCode 5
-        versionName "0.9.4.1"
+        versionName "0.9.4.2"
     }
     buildTypes {
         release {

--- a/decoviewlib/build.gradle
+++ b/decoviewlib/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 22
         versionCode 5
-        versionName "0.9.4.2"
+        versionName "0.9.4.3"
     }
     buildTypes {
         release {

--- a/decoviewlib/build.gradle
+++ b/decoviewlib/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 22
         versionCode 5
-        versionName "0.9.4"
+        versionName "0.9.4.1"
     }
     buildTypes {
         release {

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ArcSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ArcSeries.java
@@ -40,8 +40,10 @@ abstract public class ArcSeries extends ChartSeries {
      * Draw the arc in the current state
      *
      * @param canvas Canvas to draw onto
+     * @param arcAngleStart The angle of the start of the arc
+     * @param arcAngleSweep The angle to sweep
      */
-    abstract void drawArc(Canvas canvas);
+    abstract void drawArc(Canvas canvas, float arcAngleStart, float arcAngleSweep);
 
     /**
      * Draw this arc in the current position calculated by the ValueAnimator.

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ChartSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ChartSeries.java
@@ -448,7 +448,16 @@ abstract public class ChartSeries {
         mPaint.setColor(mSeriesItem.getColor());
         mPaint.setStyle((mSeriesItem.getChartStyle() == SeriesItem.ChartStyle.STYLE_DONUT) ? Paint.Style.STROKE : Paint.Style.FILL);
         mPaint.setStrokeWidth(mSeriesItem.getLineWidth());
-        mPaint.setStrokeCap(mSeriesItem.getRoundCap() ? Paint.Cap.ROUND : Paint.Cap.BUTT);
+
+        if (mSeriesItem.getEndCap() == EndCapType.CAP_CONVEX) {
+            mPaint.setStrokeCap(Paint.Cap.ROUND);
+        } else if (mSeriesItem.getEndCap() == EndCapType.CAP_BUTTED) {
+            mPaint.setStrokeCap(Paint.Cap.BUTT);
+        } else if (mSeriesItem.getEndCap() == EndCapType.CAP_SQUARE) {
+            mPaint.setStrokeCap(Paint.Cap.SQUARE);
+        } else if (mSeriesItem.getEndCap() == EndCapType.CAP_CONCAVE) {
+            mPaint.setStrokeCap(Paint.Cap.ROUND);
+        }
         mPaint.setAntiAlias(true);
 
         // We need to reset the bounds for the case we are drawing a gradient and need to recreate

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/EndCapType.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/EndCapType.java
@@ -1,0 +1,13 @@
+package com.hookedonplay.decoviewlib.charts;
+
+/**
+ * Defines the end cap styles that are supported.
+ *
+ * Created by nealsanche on 15-09-01.
+ */
+public enum EndCapType {
+    CAP_CONVEX,
+    CAP_CONCAVE,
+    CAP_SQUARE,
+    CAP_BUTTED
+}

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineArcSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineArcSeries.java
@@ -104,7 +104,7 @@ public class LineArcSeries extends ArcSeries {
         mConcaveClipPath.addCircle(middleX, middleY, lineWidth, Path.Direction.CW);
         if (cleanUpAntialiasing) {
             // Add another rect to clean up the end-cap antialiasing.
-            mConcaveClipPath.addRect(middleX - lineWidth, middleY - lineWidth, middleX, middleY + lineWidth, Path.Direction.CW);
+            mConcaveClipPath.addRect(middleX - (lineWidth + 2.0f), middleY - lineWidth, middleX, middleY + lineWidth, Path.Direction.CW);
         }
         canvas.clipPath(mConcaveClipPath, Region.Op.DIFFERENCE);
     }

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineArcSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineArcSeries.java
@@ -92,11 +92,7 @@ public class LineArcSeries extends ArcSeries {
     }
 
     private void processConcaveDraw(Canvas canvas, float clipAngle, boolean cleanUpAntialiasing) {
-        float cleanupFactor = 0.0f;
-        if (cleanUpAntialiasing) {
-            cleanupFactor = 0.01f;
-        }
-        float lineWidth = (getSeriesItem().getLineWidth() * (0.5f + cleanupFactor));
+        float lineWidth = (getSeriesItem().getLineWidth() * 0.5f);
         float radius = mBoundsInset.width() / 2;
         float angle = (float)(Math.PI * clipAngle / 180.0f);
         float middleX = (float)(mBoundsInset.centerX() + radius * Math.cos(angle));
@@ -106,6 +102,10 @@ public class LineArcSeries extends ArcSeries {
         }
         mConcaveClipPath.reset();
         mConcaveClipPath.addCircle(middleX, middleY, lineWidth, Path.Direction.CW);
+        if (cleanUpAntialiasing) {
+            // Add another rect to clean up the end-cap antialiasing.
+            mConcaveClipPath.addRect(middleX - lineWidth, middleY - lineWidth, middleX, middleY + lineWidth, Path.Direction.CW);
+        }
         canvas.clipPath(mConcaveClipPath, Region.Op.DIFFERENCE);
     }
 

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/PieSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/PieSeries.java
@@ -44,13 +44,13 @@ public class PieSeries extends ArcSeries {
             return true;
         }
 
-        drawArc(canvas);
+        drawArc(canvas, mArcAngleStart, mArcAngleSweep);
         drawArcEdgeDetail(canvas);
 
         return true;
     }
 
-    protected void drawArc(@NonNull Canvas canvas) {
+    protected void drawArc(@NonNull Canvas canvas, float arcAngleStart, float arcAngleSweep) {
         canvas.drawArc(mBoundsInset,
                 mArcAngleStart,
                 mArcAngleSweep,
@@ -115,7 +115,7 @@ public class PieSeries extends ArcSeries {
         Shader shaderOld = mPaint.getShader();
         mPaint.setColor(color);
         mPaint.setShader(null);
-        drawArc(canvas);
+        drawArc(canvas, mArcAngleStart, mArcAngleSweep);
         mPaint.setColor(colorOld);
         mPaint.setShader(shaderOld);
         canvas.restore();

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/SeriesItem.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/SeriesItem.java
@@ -115,6 +115,11 @@ public class SeriesItem {
      */
     private ArrayList<SeriesItemListener> mListeners;
 
+    /**
+     * Provides the end cap type
+     */
+    private EndCapType mEndCap;
+
     private SeriesItem(Builder builder) {
         mColor = builder.mColor;
         mColorSecondary = builder.mColorSecondary;
@@ -125,7 +130,7 @@ public class SeriesItem {
         mInitialValue = builder.mInitialValue;
         mInitialVisibility = builder.mInitialVisibility;
         mSpinClockwise = builder.mSpinClockwise;
-        mRoundCap = builder.mRoundCap;
+        mEndCap = builder.mEndCap;
         mDrawAsPoint = builder.mDrawAsPoint;
         mChartStyle = builder.mChartStyle;
         mInterpolator = builder.mInterpolator;
@@ -183,8 +188,8 @@ public class SeriesItem {
         return mSpinClockwise;
     }
 
-    public boolean getRoundCap() {
-        return mRoundCap;
+    public EndCapType getEndCap() {
+        return mEndCap;
     }
 
     public boolean getDrawAsPoint() {
@@ -276,7 +281,7 @@ public class SeriesItem {
         private float mInitialValue = 0f;
         private boolean mInitialVisibility = true;
         private boolean mSpinClockwise = true;
-        private boolean mRoundCap = true;
+        private EndCapType mEndCap = EndCapType.CAP_CONVEX;
         private boolean mDrawAsPoint = false;
         private ChartStyle mChartStyle = ChartStyle.STYLE_DONUT;
         private Interpolator mInterpolator;
@@ -318,7 +323,16 @@ public class SeriesItem {
         }
 
         public Builder setCapRounded(final boolean roundCap) {
-            mRoundCap = roundCap;
+            if (roundCap) {
+                mEndCap = EndCapType.CAP_CONVEX;
+            } else {
+                mEndCap = EndCapType.CAP_BUTTED;
+            }
+            return this;
+        }
+
+        public Builder setEndCap(final EndCapType capType) {
+            mEndCap = capType;
             return this;
         }
 


### PR DESCRIPTION
- Adds new EndCap builder method, and leaves the setRoundedCap method.
- Adds another page to the demo app which shows the new functionality.
- Makes an attempt at getting the concave drawing working along with edge effects.
- Definitely not perfect, and has a few antialiasing artifacts.
- More of an example pull request, as I don't expect this to be added directly to your master.