### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleFragment.java
@@ -67,7 +67,7 @@ abstract public class SampleFragment extends Fragment {
                 if (mUpdateListeners) {
                     if (format.contains("%%")) {
                         // We found a percentage so we insert a percentage
-                        float percentFilled = ((currentPosition - seriesItem.getMinValue()) / (seriesItem.getMaxValue() - seriesItem.getMinValue()));
+                        float percentFilled = (currentPosition - seriesItem.getMinValue()) / (seriesItem.getMaxValue() - seriesItem.getMinValue());
                         view.setText(String.format(format, percentFilled * 100f));
                     } else {
                         view.setText(String.format(format, currentPosition));

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ChartSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/ChartSeries.java
@@ -205,8 +205,8 @@ abstract public class ChartSeries {
              * of a revolution multiplied by the default time for a full revolution. This ensures
              * that the speed of the move is consistent for all ranges
              */
-            animationDuration = (Math.abs((int) (mSeriesItem.getSpinDuration() *
-                    ((mPositionStart - mPositionEnd) / mSeriesItem.getMaxValue()))));
+            animationDuration = Math.abs((int) (mSeriesItem.getSpinDuration() *
+                    ((mPositionStart - mPositionEnd) / mSeriesItem.getMaxValue())));
 
         }
 
@@ -607,7 +607,7 @@ abstract public class ChartSeries {
         max -= min;
 
         if (Math.abs(start - end) < 0.01) {
-            return (start / max);
+            return start / max;
         }
 
         if ((mDrawMode == DecoEvent.EventType.EVENT_HIDE) ||

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/DecoDrawEffect.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/DecoDrawEffect.java
@@ -174,7 +174,7 @@ public class DecoDrawEffect {
                 if (percentComplete <= step) {
                     drawMoveToCenter(canvas, bounds, percentComplete * (1f / step), startAngle, sweepAngle);
                 } else {
-                    final float remain = (1.0f - step);
+                    final float remain = 1.0f - step;
                     drawExplode(canvas, bounds, (percentComplete - step) / remain);
                     drawText(canvas, bounds, (percentComplete - step) / remain);
                 }
@@ -211,8 +211,8 @@ public class DecoDrawEffect {
                                  float percentComplete, float startAngle, float sweepAngle) {
 
         // Animation moves outward from center to outside
-        final boolean moveOutward = (mEffectType == EffectType.EFFECT_SPIRAL_OUT ||
-                mEffectType == EffectType.EFFECT_SPIRAL_OUT_FILL);
+        final boolean moveOutward = mEffectType == EffectType.EFFECT_SPIRAL_OUT ||
+                mEffectType == EffectType.EFFECT_SPIRAL_OUT_FILL;
 
         // Animation spins in a clockwise direction
         final boolean spinClockwise = mEffectType != EffectType.EFFECT_SPIRAL_IN &&
@@ -224,7 +224,7 @@ public class DecoDrawEffect {
         final float baseRotateAngle = mCircuits * 360f;
 
         float rotateAmount = (mEffectType == EffectType.EFFECT_SPIRAL_OUT_FILL) ? baseRotateAngle + 360f : baseRotateAngle;
-        float rotateOffset = (rotateAmount * percentComplete);
+        float rotateOffset = rotateAmount * percentComplete;
         float newAngle = (startAngle + (spinClockwise ? rotateOffset : -rotateOffset)) % 360;
         float sweep = getSweepAngle(percentComplete);
 
@@ -314,14 +314,14 @@ public class DecoDrawEffect {
      */
     public void drawExplode(@NonNull Canvas canvas, RectF bounds, float percentComplete) {
         boolean drawCircles = Build.VERSION.SDK_INT <= 17;
-        final float maxLength = (bounds.width() * EXPLODE_LINE_MAX);
-        final float minLength = (bounds.width() * EXPLODE_LINE_MIN);
-        final float startPosition = (bounds.width() * EXPLODE_LINE_MAX);
+        final float maxLength = bounds.width() * EXPLODE_LINE_MAX;
+        final float minLength = bounds.width() * EXPLODE_LINE_MIN;
+        final float startPosition = bounds.width() * EXPLODE_LINE_MAX;
         int alpha = MAX_ALPHA;
 
         float length;
         if (percentComplete > 0.5f) {
-            float completed = ((percentComplete - 0.5f) * 2);
+            float completed = (percentComplete - 0.5f) * 2;
             length = maxLength - (completed * (maxLength - minLength));
             alpha = MAX_ALPHA - (int) (MAX_ALPHA * completed);
         } else {

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineSeries.java
@@ -46,7 +46,7 @@ public class LineSeries extends ChartSeries {
         final boolean reverse = !mSeriesItem.getSpinClockwise();
         float insetX = mSeriesItem.getInset() != null ? mSeriesItem.getInset().x : 0;
         float insetY = mSeriesItem.getInset() != null ? mSeriesItem.getInset().y : 0;
-        float lineWidth = (getSeriesItem().getLineWidth() / 2);
+        float lineWidth = getSeriesItem().getLineWidth() / 2;
         float posNow = mPositionCurrentEnd / (getSeriesItem().getMaxValue() - getSeriesItem().getMinValue());
         if (this.getSeriesItem().showPointWhenEmpty()) {
             /* Adjust to show point even when empty */
@@ -57,10 +57,10 @@ public class LineSeries extends ChartSeries {
 
         final float totalWidth = posNow * (canvas.getWidth() - (2 * lineWidth));
         final float totalHeight = posNow * (canvas.getHeight() - (2 * lineWidth));
-        float xVal1 = (!reverse ? lineWidth : canvas.getWidth() - lineWidth);
-        float yVal1 = (!reverse ? lineWidth : canvas.getHeight() - lineWidth);
-        float xVal2 = (!reverse ? lineWidth + totalWidth : xVal1 - totalWidth);
-        float yVal2 = (!reverse ? lineWidth + totalHeight : yVal1 - totalHeight);
+        float xVal1 = !reverse ? lineWidth : canvas.getWidth() - lineWidth;
+        float yVal1 = !reverse ? lineWidth : canvas.getHeight() - lineWidth;
+        float xVal2 = !reverse ? lineWidth + totalWidth : xVal1 - totalWidth;
+        float yVal2 = !reverse ? lineWidth + totalHeight : yVal1 - totalHeight;
 
         if (isHorizontal()) {
             switch (mVertGravity) {

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/SeriesLabel.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/SeriesLabel.java
@@ -99,7 +99,7 @@ public class SeriesLabel {
             mTextBounds = new Rect();
             mPaintText.getTextBounds(mLabel, 0, mLabel.length(), mTextBounds);
             mTextDraw = new RectF();
-            mTextCenter = ((mPaintText.descent() + mPaintText.ascent()) / 2);
+            mTextCenter = (mPaintText.descent() + mPaintText.ascent()) / 2;
         }
     }
 

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/events/DecoEventManager.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/events/DecoEventManager.java
@@ -62,7 +62,7 @@ public class DecoEventManager {
                 (event.getEffectType() == DecoDrawEffect.EffectType.EFFECT_SPIRAL_OUT) ||
                 (event.getEffectType() == DecoDrawEffect.EffectType.EFFECT_SPIRAL_OUT_FILL);
 
-        final boolean ignore = (event.getEventType() == DecoEvent.EventType.EVENT_MOVE);
+        final boolean ignore = event.getEventType() == DecoEvent.EventType.EVENT_MOVE;
 
         mHandler.postDelayed(new Runnable() {
             @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat