### PR TITLE
squid:S1197, squid:S1066 - Array designators [] should be on the type…

### DIFF
--- a/app/src/main/java/com/hookedonplay/decoviewsample/Sample3Fragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/Sample3Fragment.java
@@ -44,7 +44,7 @@ public class Sample3Fragment extends SampleFragment {
             Color.parseColor("#F44366"),
             Color.parseColor("#FFF9C4")
     };
-    private int mSeriesIndex[] = new int[7];
+    private int[] mSeriesIndex = new int[7];
     private int mBackIndex;
     private boolean mFullCircle = true;
     private boolean mFlip = true;

--- a/app/src/main/java/com/hookedonplay/decoviewsample/Sample4Fragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/Sample4Fragment.java
@@ -43,7 +43,7 @@ public class Sample4Fragment extends SampleFragment {
             Color.parseColor("#DDDDDD"),
             Color.parseColor("#2222FF")
     };
-    private int mSeriesIndex[] = new int[7];
+    private int[] mSeriesIndex = new int[7];
     private int mBackIndex;
     private boolean mFullCircle = true;
     private boolean mFlip = true;

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/DecoView.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/DecoView.java
@@ -26,7 +26,6 @@ import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
-
 import com.hookedonplay.decoviewlib.charts.ChartSeries;
 import com.hookedonplay.decoviewlib.charts.DecoDrawEffect;
 import com.hookedonplay.decoviewlib.charts.LineArcSeries;
@@ -85,7 +84,7 @@ public class DecoView extends View implements DecoEventManager.ArcEventManagerLi
      * {@link DecoView}
      */
     private DecoEventManager mDecoEventManager;
-    private float mMeasureViewableArea[];
+    private float[] mMeasureViewableArea;
 
     public DecoView(Context context) {
         super(context);
@@ -385,10 +384,8 @@ public class DecoView extends View implements DecoEventManager.ArcEventManagerLi
         // We only need to check those series drawn after this series
         for (int i = index + 1; i < mChartSeries.size(); i++) {
             ChartSeries innerSeries = mChartSeries.get(i);
-            if (innerSeries.isVisible()) {
-                if (max < innerSeries.getPositionPercent()) {
-                    max = innerSeries.getPositionPercent();
-                }
+            if (innerSeries.isVisible() && max < innerSeries.getPositionPercent()) {
+                max = innerSeries.getPositionPercent();
             }
         }
 

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineSeries.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/charts/LineSeries.java
@@ -23,7 +23,6 @@ import android.graphics.RectF;
 import android.graphics.Shader;
 import android.support.annotation.NonNull;
 import android.util.Log;
-
 import com.hookedonplay.decoviewlib.DecoView;
 
 public class LineSeries extends ChartSeries {
@@ -48,11 +47,10 @@ public class LineSeries extends ChartSeries {
         float insetY = mSeriesItem.getInset() != null ? mSeriesItem.getInset().y : 0;
         float lineWidth = getSeriesItem().getLineWidth() / 2;
         float posNow = mPositionCurrentEnd / (getSeriesItem().getMaxValue() - getSeriesItem().getMinValue());
-        if (this.getSeriesItem().showPointWhenEmpty()) {
-            /* Adjust to show point even when empty */
-            if (Math.abs(posNow) < 0.01f) {
-                posNow = 0.01f;
-            }
+
+        /* Adjust to show point even when empty */
+        if (this.getSeriesItem().showPointWhenEmpty() && Math.abs(posNow) < 0.01f) {
+            posNow = 0.01f;
         }
 
         final float totalWidth = posNow * (canvas.getWidth() - (2 * lineWidth));

--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/events/DecoEventManager.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/events/DecoEventManager.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.widget.TextView;
-
 import com.hookedonplay.decoviewlib.charts.DecoDrawEffect;
 
 /**
@@ -67,22 +66,18 @@ public class DecoEventManager {
         mHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                if (show) {
-                    if (event.getLinkedViews() != null) {
-                        for (View view : event.getLinkedViews()) {
+                if (show && event.getLinkedViews() != null) {
+                    for (View view : event.getLinkedViews()) {
 
-                            // Issue with ICS where View is not displayed after the setVisibility() call if it has no text
-                            // This results in subsequent calls to setText also not being visible
-                            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-                                if (view instanceof TextView) {
-                                    TextView textView = (TextView) view;
-                                    if (textView.getText().length() <= 0) {
-                                        textView.setText(" ");
-                                    }
-                                }
+                        // Issue with ICS where View is not displayed after the setVisibility() call if it has no text
+                        // This results in subsequent calls to setText also not being visible
+                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1 && view instanceof TextView) {
+                            TextView textView = (TextView) view;
+                            if (textView.getText().length() <= 0) {
+                                textView.setText(" ");
                             }
-                            view.setVisibility(View.VISIBLE);
                         }
+                        view.setVisibility(View.VISIBLE);
                     }
                 }
                 if (!ignore && event.getLinkedViews() != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1197 - Array designators "[]" should be on the type, not the variable
squid:S1066 - Collapsible "if" statements should be merged

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1066

Please let me know if you have any questions.

M-Ezzat