### PR TITLE
squid:S1941 - Variables should not be declared before they are relevant

### DIFF
--- a/app/src/main/java/com/hookedonplay/decoviewsample/Sample1Fragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/Sample1Fragment.java
@@ -42,7 +42,6 @@ public class Sample1Fragment extends SampleFragment {
     @Override
     protected void createTracks() {
         setDemoFinished(false);
-        final float seriesMax = 50f;
         final DecoView decoView = getDecoView();
         final View view = getView();
         if (decoView == null || view == null) {
@@ -51,6 +50,7 @@ public class Sample1Fragment extends SampleFragment {
         decoView.deleteAll();
         decoView.configureAngles(280, 0);
 
+        final float seriesMax = 50f;
         decoView.addSeries(new SeriesItem.Builder(Color.argb(255, 64, 255, 64), Color.argb(255, 255, 0, 0))
                 .setRange(0, seriesMax, seriesMax)
                 .setInitialVisibility(false)

--- a/app/src/main/java/com/hookedonplay/decoviewsample/Sample2Fragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/Sample2Fragment.java
@@ -44,7 +44,6 @@ public class Sample2Fragment extends SampleFragment {
     @Override
     protected void createTracks() {
         setDemoFinished(false);
-        final float seriesMax = 50f;
         final DecoView decoView = getDecoView();
         final View view = getView();
         if (decoView == null || view == null) {
@@ -53,6 +52,7 @@ public class Sample2Fragment extends SampleFragment {
         decoView.deleteAll();
         decoView.configureAngles(280, 0);
 
+        final float seriesMax = 50f;
         decoView.addSeries(new SeriesItem.Builder(Color.argb(255, 218, 218, 218))
                 .setRange(0, seriesMax, seriesMax)
                 .setInitialVisibility(false)

--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleFitFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleFitFragment.java
@@ -54,7 +54,6 @@ public class SampleFitFragment extends SampleFragment {
     @Override
     protected void createTracks() {
         setDemoFinished(false);
-        final float seriesMax = 50f;
         final DecoView decoView = getDecoView();
         final View view = getView();
         if (decoView == null || view == null) {
@@ -63,6 +62,7 @@ public class SampleFitFragment extends SampleFragment {
         decoView.deleteAll();
         decoView.configureAngles(mTotalAngle[mStyleIndex], mRotateAngle[mStyleIndex]);
 
+        final float seriesMax = 50f;
         SeriesItem arcBackTrack = new SeriesItem.Builder(Color.argb(255, 228, 228, 228))
                 .setRange(0, seriesMax, seriesMax)
                 .setInitialVisibility(false)

--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleGenericFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleGenericFragment.java
@@ -55,7 +55,6 @@ public class SampleGenericFragment extends SampleFragment {
     @Override
     protected void createTracks() {
         setDemoFinished(false);
-        final float seriesMax = 50f;
         final DecoView arcView = getDecoView();
         final View view = getView();
         if (arcView == null || view == null) {
@@ -64,6 +63,7 @@ public class SampleGenericFragment extends SampleFragment {
         arcView.deleteAll();
         arcView.configureAngles(mTotalAngle[mStyleIndex], mRotateAngle[mStyleIndex]);
 
+        final float seriesMax = 50f;
         SeriesItem arcBackTrack = new SeriesItem.Builder(Color.argb(255, 228, 228, 228))
                 .setRange(0, seriesMax, seriesMax)
                 .setInitialVisibility(false)

--- a/app/src/main/java/com/hookedonplay/decoviewsample/SampleInterpolatorsFragment.java
+++ b/app/src/main/java/com/hookedonplay/decoviewsample/SampleInterpolatorsFragment.java
@@ -71,7 +71,6 @@ public class SampleInterpolatorsFragment extends SampleFragment {
     }
 
     private void createTracks(int arcViewId, Interpolator interpolator, int color) {
-        final float mSeriesMax = 50f;
         final View view = getView();
         if (view == null) {
             return;
@@ -85,6 +84,7 @@ public class SampleInterpolatorsFragment extends SampleFragment {
         decoView.deleteAll();
         decoView.configureAngles(320, 180);
 
+        final float mSeriesMax = 50f;
         SeriesItem arcBackTrack = new SeriesItem.Builder(Color.argb(255, 228, 228, 228))
                 .setRange(0, mSeriesMax, mSeriesMax)
                 .setLineWidth(getDimension(12f))


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat