### PR TITLE
Added fitToSize

### DIFF
--- a/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/DecoView.java
+++ b/decoviewlib/src/main/java/com/hookedonplay/decoviewlib/DecoView.java
@@ -80,6 +80,10 @@ public class DecoView extends View implements DecoEventManager.ArcEventManagerLi
      */
     private int mTotalAngle = 360;
     /**
+     * If set to true makes the DecoView bounds squared
+     */
+    private boolean mFitToSize = false;
+    /**
      * Event manager that controls the timing of events to be executed on the
      * {@link DecoView}
      */
@@ -101,6 +105,7 @@ public class DecoView extends View implements DecoEventManager.ArcEventManagerLi
 
         int rotateAngle = 0;
         try {
+            mFitToSize = a.getBoolean(R.styleable.DecoView_dv_fitToSize, false);
             mDefaultLineWidth = a.getDimension(R.styleable.DecoView_dv_lineWidth, 30f);
             rotateAngle = a.getInt(R.styleable.DecoView_dv_rotateAngle, 0);
             mTotalAngle = a.getInt(R.styleable.DecoView_dv_totalAngle, 360);
@@ -256,6 +261,21 @@ public class DecoView extends View implements DecoEventManager.ArcEventManagerLi
         mCanvasHeight = height;
 
         recalcLayout();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = getDefaultSize(getSuggestedMinimumWidth(), widthMeasureSpec);
+        int height = getDefaultSize(getSuggestedMinimumHeight(), heightMeasureSpec);
+        if(mFitToSize) {
+            if(height >= width) {
+                setMeasuredDimension(width, width);
+            } else {
+                setMeasuredDimension(height, height);
+            }
+        } else {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        }
     }
 
     /**

--- a/decoviewlib/src/main/res/values/attr.xml
+++ b/decoviewlib/src/main/res/values/attr.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="DecoView">
+        <attr name="dv_fitToSize" format="boolean" />
         <attr name="dv_lineWidth" format="dimension" />
         <attr name="dv_rotateAngle" format="integer" />
         <attr name="dv_totalAngle" format="integer" />


### PR DESCRIPTION
Implemented new attribute dv_fitToSize, if set to true it will make the view square (not just the canvas), so its size is going to be the smallest of the width or height, allowing for other widgets to be right next to it in LinearLayouts, RelativeLayouts, etc..
Because the View will no longer occupy the full screen, dv_arc_gravity_horizontal and dv_arc_gravity_vertical will no longer work, so the user can use the regular ways to align a view, like changing the gravity setting of its parent layout.
